### PR TITLE
Making apt-get install non interactive by default

### DIFF
--- a/fabelt/apt.py
+++ b/fabelt/apt.py
@@ -4,4 +4,4 @@ from fabric.api import task, run
 @task()
 def install(package):
     args = dict(package=package)
-    run('apt-get install {package}'.format(**args))
+    run('apt-get -y --quiet install {package}'.format(**args))


### PR DESCRIPTION
apt-get install will ask for confirmation after selecting packages to be installed, options -y and --quiet are required to non interactive tasks.